### PR TITLE
Decouple inference of lib directory from the QuickbooksConfig so the

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,15 +24,15 @@ Add the JARs as dependencies
 ```
 groupId: com.inetsoft.connectors
 artifactId: spark-quickbooks
-version: 1.0.0-SNAPSHOT
+version: 1.0.1-SNAPSHOT
 classifier: bundle
 ```
 
-#### QuickBooks Runtime
+#### QuickBooks API
 ```
 groupId: com.inetsoft.connectors
 artifactId: spark-quickbooks-api
-version: 1.0.0-SNAPSHOT
+version: 1.0.1-SNAPSHOT
 ```
 
 ## Options

--- a/spark-quickbooks-api/src/main/java/inetsoft/spark/quickbooks/QuickbooksUtil.java
+++ b/spark-quickbooks-api/src/main/java/inetsoft/spark/quickbooks/QuickbooksUtil.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2019 InetSoft Technology
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package inetsoft.spark.quickbooks;
+
+public class QuickbooksUtil {
+   public static String getQbLibDir() {
+      return qbLibDir;
+   }
+
+   private static String qbLibDir;
+
+   static {
+      final String envLib = System.getenv("QUICKBOOKS_LIB");
+      qbLibDir = (envLib != null) ? envLib : (System.getProperty("user.home") + "/quickbooks-lib");
+   }
+}

--- a/spark-quickbooks-runtime/src/main/java/inetsoft/spark/quickbooks/QuickbooksConfig.java
+++ b/spark-quickbooks-runtime/src/main/java/inetsoft/spark/quickbooks/QuickbooksConfig.java
@@ -38,10 +38,6 @@ public class QuickbooksConfig {
       this.expiration = expiration;
    }
 
-   public static String getQbLibDir() {
-      return qbLibDir;
-   }
-
    public static QuickbooksConfig readConfig(String clientId, String companyId) {
       final File file = getConfigFile(clientId, companyId);
 
@@ -106,13 +102,7 @@ public class QuickbooksConfig {
    }
 
    private static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
-   private static final String qbLibDir;
-
-   static {
-      final String envLib = System.getenv("QUICKBOOKS_LIB");
-      qbLibDir = (envLib != null) ? envLib : (System.getProperty("user.home") + "/quickbooks-lib");
-   }
-
+   private static final String qbLibDir = QuickbooksUtil.getQbLibDir();
    private final String accessToken;
    private final String refreshToken;
    private final long expiration;

--- a/spark-quickbooks/src/main/java/inetsoft/spark/quickbooks/source/QuickbooksClassloader.java
+++ b/spark-quickbooks/src/main/java/inetsoft/spark/quickbooks/source/QuickbooksClassloader.java
@@ -15,7 +15,7 @@
  */
 package inetsoft.spark.quickbooks.source;
 
-import inetsoft.spark.quickbooks.QuickbooksConfig;
+import inetsoft.spark.quickbooks.QuickbooksUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -40,7 +40,7 @@ public class QuickbooksClassloader extends URLClassLoader {
       final URL location =
          QuickbooksClassloader.class.getProtectionDomain().getCodeSource().getLocation();
       final File quickbooksJar = new File(location.toURI());
-      final File libDir = new File(QuickbooksConfig.getQbLibDir());
+      final File libDir = new File(QuickbooksUtil.getQbLibDir());
 
       if(libDir.mkdir() || libDir.lastModified() < quickbooksJar.lastModified()) {
          final JarFile jarFile = new JarFile(quickbooksJar);


### PR DESCRIPTION
runtime JAR isn't required before the bundle is extracted.