### PR TITLE
Delete old dependencies when updating the JAR

### DIFF
--- a/spark-quickbooks-api/src/main/java/inetsoft/spark/quickbooks/QuickbooksAPI.java
+++ b/spark-quickbooks-api/src/main/java/inetsoft/spark/quickbooks/QuickbooksAPI.java
@@ -23,7 +23,7 @@ public interface QuickbooksAPI {
                                   String authorizationCode,
                                   String companyID,
                                   String redirectUrl,
-                                  String apiUrl,
+                                  boolean production,
                                   String entity);
 
    interface QuickbooksQueryResult {

--- a/spark-quickbooks-runtime/src/main/java/inetsoft/spark/quickbooks/QuickbooksRuntime.java
+++ b/spark-quickbooks-runtime/src/main/java/inetsoft/spark/quickbooks/QuickbooksRuntime.java
@@ -40,7 +40,7 @@ public class QuickbooksRuntime implements QuickbooksAPI {
                                          String authorizationCode,
                                          String companyId,
                                          String redirectUrl,
-                                         String apiUrl,
+                                         boolean production,
                                          String entity)
    {
       this.clientId = clientId;
@@ -48,7 +48,7 @@ public class QuickbooksRuntime implements QuickbooksAPI {
       this.authorizationCode = authorizationCode;
       this.companyId = companyId;
       this.redirectUrl = redirectUrl;
-      this.apiUrl = apiUrl;
+      this.production = production;
       this.entity = entity;
       return loadData(QuickbooksConfig.readConfig(clientId, companyId));
    }
@@ -64,7 +64,7 @@ public class QuickbooksRuntime implements QuickbooksAPI {
 
          // check tokens
          OAuth2Config oauth2Config = new OAuth2Config.OAuth2ConfigBuilder(clientId, clientSecret)
-            .callDiscoveryAPI(Environment.SANDBOX)
+            .callDiscoveryAPI(production ? Environment.PRODUCTION : Environment.SANDBOX)
             .buildConfig();
          client = new OAuth2PlatformClient(oauth2Config);
          final String accessToken = connect(config);
@@ -94,6 +94,7 @@ public class QuickbooksRuntime implements QuickbooksAPI {
                                String companyId,
                                String accessToken) throws FMSException
    {
+      final String apiUrl = production ? productionUrl : sandboxUrl;
       Config.setProperty(Config.BASE_URL_QBO, apiUrl);
       OAuth2Authorizer oauth = new OAuth2Authorizer(accessToken);
       Context context = new Context(oauth, ServiceType.QBO, companyId);
@@ -162,6 +163,8 @@ public class QuickbooksRuntime implements QuickbooksAPI {
       private QueryResult queryResult;
    }
 
+   private static final String sandboxUrl = "https://sandbox-quickbooks.api.intuit.com/v3/company";
+   private static final String productionUrl = "https://quickbooks.api.intuit.com/v3/company";
    private final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
    private OAuth2PlatformClient client;
    private String clientId;
@@ -169,6 +172,6 @@ public class QuickbooksRuntime implements QuickbooksAPI {
    private String authorizationCode;
    private String companyId;
    private String redirectUrl;
-   private String apiUrl;
+   private boolean production;
    private String entity;
 }

--- a/spark-quickbooks/src/main/java/inetsoft/spark/quickbooks/source/DefaultSource.java
+++ b/spark-quickbooks/src/main/java/inetsoft/spark/quickbooks/source/DefaultSource.java
@@ -28,12 +28,10 @@ public class DefaultSource implements DataSourceV2, ReadSupport {
       final String redirectUrl = options.get("redirectUrl").orElse(URL);
       final String entity = options.get("entity").orElse("companyInfo");
       final String mode = options.get("production").orElse("false");
-      final String apiUrl = Boolean.TRUE.toString().equals(mode) ? productionUrl : sandboxUrl;
+      final boolean production = Boolean.TRUE.toString().equals(mode);
       return new QuickbooksReader(clientId, clientSecret, authorizationCode,
-                                  companyId, redirectUrl, apiUrl, entity);
+                                  companyId, redirectUrl, production, entity);
    }
 
    private static final String URL = "https://developer.intuit.com/v2/OAuth2Playground/RedirectUrl";
-   private static final String sandboxUrl = "https://sandbox-quickbooks.api.intuit.com/v3/company";
-   private static final String productionUrl = "https://quickbooks.api.intuit.com/v3/company";
 }

--- a/spark-quickbooks/src/main/java/inetsoft/spark/quickbooks/source/QuickbooksReader.java
+++ b/spark-quickbooks/src/main/java/inetsoft/spark/quickbooks/source/QuickbooksReader.java
@@ -15,8 +15,7 @@
  */
 package inetsoft.spark.quickbooks.source;
 
-import inetsoft.spark.quickbooks.SparkSchema;
-import inetsoft.spark.quickbooks.SparkSchemaGenerator;
+import inetsoft.spark.quickbooks.*;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.catalyst.expressions.GenericRowWithSchema;
 import org.apache.spark.sql.sources.v2.reader.*;
@@ -38,10 +37,10 @@ public class QuickbooksReader implements DataSourceReader {
                     String authorizationCode,
                     String companyId,
                     String redirectUrl,
-                    String apiUrl,
+                    boolean production,
                     String entity)
    {
-      reader = new QuickbooksStreamReader(clientId, clientSecret, authorizationCode, companyId, apiUrl, redirectUrl, entity);
+      reader = new QuickbooksStreamReader(clientId, clientSecret, authorizationCode, companyId, redirectUrl, production, entity);
    }
 
    @Override

--- a/spark-quickbooks/src/main/java/inetsoft/spark/quickbooks/source/QuickbooksStreamReader.java
+++ b/spark-quickbooks/src/main/java/inetsoft/spark/quickbooks/source/QuickbooksStreamReader.java
@@ -33,7 +33,7 @@ public class QuickbooksStreamReader implements Serializable {
                                  String authorizationCode,
                                  String companyId,
                                  String redirectUrl,
-                                 String apiUrl,
+                                 boolean production,
                                  String entity)
    {
       this.clientId = clientId;
@@ -41,7 +41,7 @@ public class QuickbooksStreamReader implements Serializable {
       this.authorizationCode = authorizationCode;
       this.companyId = companyId;
       this.redirectUrl = redirectUrl;
-      this.apiUrl = apiUrl;
+      this.production = production;
       this.entity = entity;
    }
 
@@ -53,7 +53,7 @@ public class QuickbooksStreamReader implements Serializable {
             classLoader.loadClass("inetsoft.spark.quickbooks.QuickbooksRuntime");
          final QuickbooksAPI api = (QuickbooksAPI) aClass.newInstance();
          final QuickbooksAPI.QuickbooksQueryResult result =
-            api.loadData(clientId, clientSecret, authorizationCode, companyId, apiUrl, redirectUrl, entity);
+            api.loadData(clientId, clientSecret, authorizationCode, companyId, redirectUrl, production, entity);
          return Collections.unmodifiableList(result.getEntities());
       }
       catch(Exception e) {
@@ -68,6 +68,6 @@ public class QuickbooksStreamReader implements Serializable {
    private final String authorizationCode;
    private final String companyId;
    private final String redirectUrl;
-   private final String apiUrl;
+   private final boolean production;
    private final String entity;
 }


### PR DESCRIPTION
After replacing the bundle JAR with a new version we should wipe out any of the old JAR files from the `QUICKBOOKS_LIB` directory so we don't run into any conflicts with versions or name changes.