### PR TITLE
User feedback

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Add the JARs as dependencies
 ```
 groupId: com.inetsoft.connectors
 artifactId: spark-quickbooks
-version: 1.0.3
+version: 1.0.4
 classifier: bundle
 ```
 
@@ -34,7 +34,7 @@ classifier: bundle
 ```
 groupId: com.inetsoft.connectors
 artifactId: spark-quickbooks-api
-version: 1.0.3
+version: 1.0.4
 ```
 
 ## Options
@@ -48,6 +48,7 @@ version: 1.0.3
 | redirectUri       | HTTPS endpoint for OAuth redirect |
 | entity            | Object to query from the API      |
 | production        | Query production environment      |
+| expandArrays      | Expands nested arrays to columns  |
 
 * `authorizationCode`: Exchanged for access/refresh tokens
 * `companyId`: Also called `realmId`, it's the ID of the company that you want to query in QuickBooks
@@ -57,6 +58,9 @@ version: 1.0.3
   * Default: `https://developer.intuit.com/v2/OAuth2Playground/RedirectUrl`
 * `entity`: Due to the nature of the QuickBooks Online query syntax, only 1 entity may be queried at a time.
 * `production`: set to `true` when switching from a sandbox to production environment
+* `expandArrays`: `true` to expand every element in an array to its own column
+    * `lineItems: [{price: 7.0}, {price: 3.0}]` becomes `lineItems_0_price, lineItems_1_price`
+    with the value 7.0 and 3.0 respectively
 
 We take this entity and pass it as the query `select * from <entity>` and then create a data frame
 from the result set to query against with Spark SQL

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Add the JARs as dependencies
 ```
 groupId: com.inetsoft.connectors
 artifactId: spark-quickbooks
-version: 1.0.4
+version: 1.1.0
 classifier: bundle
 ```
 
@@ -34,7 +34,7 @@ classifier: bundle
 ```
 groupId: com.inetsoft.connectors
 artifactId: spark-quickbooks-api
-version: 1.0.4
+version: 1.1.0
 ```
 
 ## Options

--- a/spark-quickbooks-runtime/src/main/java/inetsoft/spark/quickbooks/QuickbooksConfig.java
+++ b/spark-quickbooks-runtime/src/main/java/inetsoft/spark/quickbooks/QuickbooksConfig.java
@@ -94,8 +94,8 @@ public class QuickbooksConfig {
          writer.println(expiration);
       }
       catch(IOException e) {
-         LOG.error("Could not save OAuth configuration. Generate a new authorization code");
-         throw new RuntimeException(e);
+         final String msg = "Could not save OAuth configuration. Generate a new authorization code";
+         throw new RuntimeException(msg, e);
       }
 
       return this;

--- a/spark-quickbooks-runtime/src/main/java/inetsoft/spark/quickbooks/QuickbooksRuntime.java
+++ b/spark-quickbooks-runtime/src/main/java/inetsoft/spark/quickbooks/QuickbooksRuntime.java
@@ -143,7 +143,7 @@ public class QuickbooksRuntime implements QuickbooksAPI {
    private int getTotalCount(DataService service) throws FMSException {
       final QueryResult countResult = service.executeQuery("SELECT COUNT(*) FROM " + entity);
       final Integer totalCount = countResult.getTotalCount();
-      LOG.debug("QuickBooks count returned {} entity(-ies)", totalCount);
+      LOG.debug("QuickBooks count returned {} result(s)", totalCount);
       return totalCount != null ? totalCount : 1;
    }
 

--- a/spark-quickbooks-runtime/src/main/java/inetsoft/spark/quickbooks/QuickbooksRuntime.java
+++ b/spark-quickbooks-runtime/src/main/java/inetsoft/spark/quickbooks/QuickbooksRuntime.java
@@ -107,8 +107,7 @@ public class QuickbooksRuntime implements QuickbooksAPI {
          batchOperation.addQuery(query, String.valueOf(counter++));
          startPosition += RESULT_LIMIT;
 
-         // max 30 batches per operation
-         if(counter % 30 == 0) {
+         if(counter % BATCH_LIMIT == 0) {
             executeBatchOperation(service, entities, batchOperation);
             batchOperation = new BatchOperation();
          }
@@ -213,6 +212,8 @@ public class QuickbooksRuntime implements QuickbooksAPI {
    private static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
    // max number of results quickbooks can return
    private static final int RESULT_LIMIT = 1000;
+   // max 30 queries per batch operation
+   public static final int BATCH_LIMIT = 30;
    private OAuth2PlatformClient client;
    private String clientId;
    private String clientSecret;

--- a/spark-quickbooks-runtime/src/main/java/inetsoft/spark/quickbooks/QuickbooksRuntime.java
+++ b/spark-quickbooks-runtime/src/main/java/inetsoft/spark/quickbooks/QuickbooksRuntime.java
@@ -100,13 +100,13 @@ public class QuickbooksRuntime implements QuickbooksAPI {
       queryResult.setMaxResults(totalCount);
       final ArrayList<IEntity> entities = new ArrayList<>();
 
-      for(int remaining = totalCount; remaining > 0; remaining -= 1000) {
-         final int maxResults = Math.min(1000, remaining);
+      for(int remaining = totalCount; remaining > 0; remaining -= RESULT_LIMIT) {
+         final int maxResults = Math.min(RESULT_LIMIT, remaining);
          final String query = String.format("SELECT * FROM %s STARTPOSITION %d MAXRESULTS %d", entity, startPosition, maxResults);
          LOG.debug("Executing QuickBooks Query: {}", query);
          final QueryResult result = service.executeQuery(query);
          entities.addAll(result.getEntities());
-         startPosition = result.getStartPosition();
+         startPosition += RESULT_LIMIT;
       }
 
       queryResult.setEntities(entities);
@@ -187,6 +187,8 @@ public class QuickbooksRuntime implements QuickbooksAPI {
    private static final String sandboxUrl = "https://sandbox-quickbooks.api.intuit.com/v3/company";
    private static final String productionUrl = "https://quickbooks.api.intuit.com/v3/company";
    private static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+   // max number of results quickbooks can return
+   private static final int RESULT_LIMIT = 1000;
    private OAuth2PlatformClient client;
    private String clientId;
    private String clientSecret;

--- a/spark-quickbooks/src/main/java/inetsoft/spark/quickbooks/SparkSchema.java
+++ b/spark-quickbooks/src/main/java/inetsoft/spark/quickbooks/SparkSchema.java
@@ -46,13 +46,13 @@ public class SparkSchema implements Serializable {
          String prefixedKey = parent + key;
 
          if(structType.nonEmpty()) {
-            final int arraySize = schema.getArraySize();
+            final int schemaArraySize = schema.getArraySize();
 
-            if(arraySize == 0) {
+            if(schemaArraySize == 0) {
                flattenStruct(schemas, structFields, newSchemas, key, schema, prefixedKey);
             }
             else {
-               for(int i = 0; i < arraySize; i++) {
+               for(int i = 0; i < schemaArraySize; i++) {
                   final String newKeyName = prefixedKey + "_" + i;
                   flattenStruct(schemas, structFields, newSchemas, key, schema, newKeyName);
                }

--- a/spark-quickbooks/src/main/java/inetsoft/spark/quickbooks/SparkSchemaGenerator.java
+++ b/spark-quickbooks/src/main/java/inetsoft/spark/quickbooks/SparkSchemaGenerator.java
@@ -191,7 +191,6 @@ public class SparkSchemaGenerator {
          case "Object":
             return DataTypes.BinaryType;
          default:
-            LOG.debug("Using BinaryType for [{}]", typeName);
             return DataTypes.BinaryType;
       }
    }

--- a/spark-quickbooks/src/main/java/inetsoft/spark/quickbooks/SparkSchemaGenerator.java
+++ b/spark-quickbooks/src/main/java/inetsoft/spark/quickbooks/SparkSchemaGenerator.java
@@ -62,7 +62,6 @@ public class SparkSchemaGenerator {
                structType = structType.merge(s);
                sparkSchema.setStructType(structType);
                sparkSchema.setMethodName(propertyName, readMethod.getName());
-               LOG.debug(structType.toString());
             }
          }
       }
@@ -118,8 +117,8 @@ public class SparkSchemaGenerator {
    private StructField createArrayField(String propertyName, Collection children, SparkSchema schema) {
       StructField field;
       final SparkSchema sparkSchema = generateSchema(children.toArray());
-      schema.addSchema(propertyName, sparkSchema);
       sparkSchema.setArraySize(children.size());
+      schema.addSchema(propertyName, sparkSchema);
       final StructType complexStructType = sparkSchema.getStructType();
       field = new StructField(propertyName,
                               DataTypes.createArrayType(complexStructType, true),
@@ -191,5 +190,5 @@ public class SparkSchemaGenerator {
       }
    }
 
-   private final static Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+   private static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 }

--- a/spark-quickbooks/src/main/java/inetsoft/spark/quickbooks/SparkSchemaGenerator.java
+++ b/spark-quickbooks/src/main/java/inetsoft/spark/quickbooks/SparkSchemaGenerator.java
@@ -89,7 +89,7 @@ public class SparkSchemaGenerator {
 
       // primitive or primitive wrapper
       if(!type.sameType(DataTypes.BinaryType)) {
-         field = new StructField(propertyName, type, !propertyType.isPrimitive(), Metadata.empty());
+         field = new StructField(propertyName, type, true, Metadata.empty());
          schema.addSchema(propertyName, new SparkSchema());
       }
       // object
@@ -104,7 +104,6 @@ public class SparkSchemaGenerator {
             final SparkSchema nestedSchema = generateSchema(propertyValue);
             final StructType structType = nestedSchema.getStructType();
             schema.addSchema(propertyName, nestedSchema);
-            schema.setStructType(propertyName, structType);
             field = new StructField(propertyName, structType, true, Metadata.empty());
          }
       }
@@ -120,8 +119,8 @@ public class SparkSchemaGenerator {
       StructField field;
       final SparkSchema sparkSchema = generateSchema(children.toArray());
       schema.addSchema(propertyName, sparkSchema);
+      sparkSchema.setArraySize(children.size());
       final StructType complexStructType = sparkSchema.getStructType();
-      schema.setStructType(propertyName, complexStructType);
       field = new StructField(propertyName,
                               DataTypes.createArrayType(complexStructType, true),
                               true,

--- a/spark-quickbooks/src/main/java/inetsoft/spark/quickbooks/SparkSchemaGenerator.java
+++ b/spark-quickbooks/src/main/java/inetsoft/spark/quickbooks/SparkSchemaGenerator.java
@@ -128,14 +128,20 @@ public class SparkSchemaGenerator {
    }
 
    private List<PropertyDescriptor> getPropertyDescriptors(Class<?> clazz) {
+      if(descriptorCache.containsKey(clazz)) {
+         return descriptorCache.get(clazz);
+      }
+
       try {
          BeanInfo beanInfo = Introspector.getBeanInfo(clazz, Object.class);
          final PropertyDescriptor[] propertyDescriptors = beanInfo.getPropertyDescriptors();
 
          if(propertyDescriptors != null) {
-            return Arrays.stream(propertyDescriptors)
-                         .filter(Objects::nonNull)
-                         .collect(Collectors.toList());
+            final List<PropertyDescriptor> list = Arrays.stream(propertyDescriptors)
+                                                        .filter(Objects::nonNull)
+                                                        .collect(Collectors.toList());
+            descriptorCache.put(clazz, list);
+            return list;
          }
       }
       catch(IntrospectionException e) {
@@ -190,5 +196,6 @@ public class SparkSchemaGenerator {
       }
    }
 
+   private static final Map<Class, List<PropertyDescriptor>> descriptorCache = new HashMap<>();
    private static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 }

--- a/spark-quickbooks/src/main/java/inetsoft/spark/quickbooks/source/DefaultSource.java
+++ b/spark-quickbooks/src/main/java/inetsoft/spark/quickbooks/source/DefaultSource.java
@@ -27,10 +27,14 @@ public class DefaultSource implements DataSourceV2, ReadSupport {
       final String companyId = options.get("companyId").orElse("");
       final String redirectUrl = options.get("redirectUrl").orElse(URL);
       final String entity = options.get("entity").orElse("companyInfo");
-      final String mode = options.get("production").orElse("false");
-      final boolean production = Boolean.TRUE.toString().equals(mode);
+      final boolean expandArrays = options.get("expandArrays")
+                                          .map(Boolean.TRUE.toString()::equals)
+                                          .orElse(false);
+      final boolean production = options.get("production")
+                                        .map(Boolean.TRUE.toString()::equals)
+                                        .orElse(false);
       return new QuickbooksReader(clientId, clientSecret, authorizationCode,
-                                  companyId, redirectUrl, production, entity);
+                                  companyId, redirectUrl, production, expandArrays, entity);
    }
 
    private static final String URL = "https://developer.intuit.com/v2/OAuth2Playground/RedirectUrl";

--- a/spark-quickbooks/src/main/java/inetsoft/spark/quickbooks/source/QuickbooksReader.java
+++ b/spark-quickbooks/src/main/java/inetsoft/spark/quickbooks/source/QuickbooksReader.java
@@ -63,7 +63,7 @@ public class QuickbooksReader implements DataSourceReader {
 
    private SparkSchema getSparkSchema(List<Object> entities) {
       final SparkSchema sparkSchema = sparkSchemaGenerator.generateSchema(entities.toArray());
-      return expandArrays ? sparkSchema.flatten() : sparkSchema;
+      return sparkSchema.flatten(expandArrays);
    }
 
    private static class TaskDataReader implements DataReader<Row> {
@@ -123,12 +123,12 @@ public class QuickbooksReader implements DataSourceReader {
          final String name = field.name();
          final String[] tokens = name.split("_");
          final String fieldName = tokens[0];
-         SparkSchema schema = parentSchema.getSchema(fieldName);
+         final SparkSchema schema = parentSchema.getSchema(fieldName);
          final String methodName = parentSchema.getMethodName(fieldName);
          // get the POJO getter name from the schema
          Object result = callMethodOnObject(parentObject, methodName);
 
-         if(tokens.length > 1) {
+         if(schema != null && schema.isFlattened()) {
             SparkSchema currentParent = parentSchema;
 
             for(int i = 1; i < tokens.length; i++) {

--- a/spark-quickbooks/src/main/java/inetsoft/spark/quickbooks/source/QuickbooksReader.java
+++ b/spark-quickbooks/src/main/java/inetsoft/spark/quickbooks/source/QuickbooksReader.java
@@ -15,11 +15,12 @@
  */
 package inetsoft.spark.quickbooks.source;
 
-import inetsoft.spark.quickbooks.*;
+import inetsoft.spark.quickbooks.SparkSchema;
+import inetsoft.spark.quickbooks.SparkSchemaGenerator;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.catalyst.expressions.GenericRowWithSchema;
 import org.apache.spark.sql.sources.v2.reader.*;
-import org.apache.spark.sql.types.StructType;
+import org.apache.spark.sql.types.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -55,7 +56,7 @@ public class QuickbooksReader implements DataSourceReader {
 
    private SparkSchema getSparkSchema(List<Object> entities) {
       try {
-         return sparkSchemaGenerator.generateSchema(entities.toArray());
+         return sparkSchemaGenerator.generateSchema(entities.toArray()).flatten();
       }
       catch(Exception e) {
          LOG.error("Failed to generate schema for {}", getClass(), e);
@@ -92,51 +93,131 @@ public class QuickbooksReader implements DataSourceReader {
 
       @Override
       public Row get() {
-         return getRow(currObj, schema);
+         return createRow(currObj, schema);
       }
 
-      private Row getRow(Object data, SparkSchema schema) {
-         if(data == null) {
+      private Row createRow(Object data, SparkSchema dataSchema) {
+         if(data == null || dataSchema == null) {
             return null;
          }
 
-         final List<Object> cells = new ArrayList<>();
+         final ArrayList<Object> cells = new ArrayList<>();
+         final StructType structType = dataSchema.getStructType();
 
-         for(String field : schema.getStructType().fieldNames()) {
-            final String methodName = schema.getMethodName(field);
-            final StructType structType = schema.getStructType(field);
+         for(StructField structField : structType.fields()) {
+               // try to get data from object
+            final Object result = getObjectByField(data, structField, dataSchema);
+            cells.add(result);
+         }
 
-            try {
-               final Method method = data.getClass().getMethod(methodName);
-               Object result = method.invoke(data);
+         return new GenericRowWithSchema(cells.toArray(), structType);
+      }
 
-               if(structType != null) {
-                  final SparkSchema sparkSchema = schema.getSchema(field);
+      /**
+       * Get the cell parentObject for a field in the schema
+       *
+       * @param parentObject the POJO that has the field
+       * @param field        the field we are trying to create
+       * @param parentSchema the schema of the parent object
+       *
+       * @return the parentObject that will fill the cell in the row
+       */
+      private Object getObjectByField(Object parentObject, StructField field, SparkSchema parentSchema) {
+         final String name = field.name();
+         final String[] tokens = name.split("_");
+         final String fieldName = tokens[0];
+         SparkSchema schema = parentSchema.getSchema(fieldName);
+         final String methodName = parentSchema.getMethodName(fieldName);
+         // get the POJO getter name from the schema
+         Object result = callMethodOnObject(parentObject, methodName);
 
-                  if(result instanceof Collection<?>) {
-                     final ArrayList<Object> childCells = new ArrayList<>();
-                     final Iterator<?> iterator = ((Collection<?>) result).iterator();
-                     iterator.forEachRemaining(obj -> childCells.add(getRow(obj, sparkSchema)));
-                     result = childCells.toArray();
+         if(tokens.length > 1) {
+            SparkSchema currentParent = parentSchema;
+
+            for(int i = 1; i < tokens.length; i++) {
+               final String parent = tokens[i - 1];
+               String token = tokens[i];
+
+               if(result != null) {
+                  final StructType parentStructType = currentParent.getStructType();
+                  final StructField parentField = parentStructType.apply(parent);
+
+                  // if this is an array it's delimited by index e.g. customers_3_name so we
+                  // pull the 3rd element from the array and move to the next token
+                  if(parentField.dataType() instanceof ArrayType && result instanceof Collection) {
+                     final int index;
+                     final int size = ((Collection) result).size();
+
+                     if(size == 0) {
+                        return null;
+                     }
+                     else if(size > 1) {
+                        index = Integer.parseInt(token);
+                        token = tokens[++i];
+                     }
+                     else {
+                        index = 0;
+                     }
+
+                     // arrays must have consistent schema but projecting the schema onto the
+                     // values may create null elements
+                     if(index >= size) {
+                        return null;
+                     }
+
+                     final Object[] objects = ((Collection) result).toArray();
+                     result = objects[index];
                   }
-                  else {
-                     result = getRow(result, sparkSchema);
-                  }
-               }
 
-               if(result instanceof Date) {
-                  result = new java.sql.Date(((Date) result).getTime());
-               }
+                  currentParent = currentParent.getSchema(parent);
 
-               cells.add(result);
-            }
-            catch(NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
-               LOG.error(e.getMessage());
-               return null;
+                  // get the POJO getter name from the schema
+                  String meth = currentParent.getMethodName(token);
+                  result = callMethodOnObject(result, meth);
+               }
+               else {
+                  return null;
+               }
             }
          }
 
-         return new GenericRowWithSchema(cells.toArray(), schema.getStructType());
+         if(result == null || result instanceof Enum) {
+            return null;
+         }
+
+         if(field.dataType() instanceof ArrayType) {
+            final ArrayList<Object> childCells = new ArrayList<>();
+            final Iterator<?> iterator = ((Collection<?>) result).iterator();
+            SparkSchema finalSchema = schema;
+            iterator.forEachRemaining(obj -> childCells.add(createRow(obj, finalSchema)));
+            result = childCells.toArray();
+         }
+         if(field.dataType() instanceof StructType) {
+            // wrap objects in nested rows
+            result = createRow(result, schema);
+         }
+
+         if(result instanceof Date) {
+            result = new java.sql.Date(((Date) result).getTime());
+         }
+
+         return result;
+      }
+
+      private Object callMethodOnObject(Object bean, String methodName) {
+         if(methodName == null) {
+            return null;
+         }
+
+         try {
+            // get the getter method from the object class
+            final Method method = bean.getClass().getMethod(methodName);
+            return method.invoke(bean);
+         }
+         catch(NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
+            LOG.error("Failed to get data from object", e);
+            return null;
+         }
       }
 
       private SparkSchema schema;


### PR DESCRIPTION
## Flattening
Implemented struct/array flattening. Structs are now by default flattened to new columns with the field names delimited by `_`. In addition, arrays are delimited by index.

### Structs
`{account: {name: string, value: number}}` is flattened to 2 new columns
* `account_name` 
* `account_value` 

These new columns are then added to the root schema.

### Arrays
If the above struct is contained within an array column `accounts` then we will flatten it to create 4 new columns
* `accounts_0_account_name`
* `accounts_0_account_value`
* `accounts_1_account_name`
* `accounts_1_account_value`

Since arrays may be expanded to many columns you will need to set the `expandArrays` options to `true` in order to enable this behavior. Structs are expanded by default for usability especially with creating join relationships with values that may be nested fairly deeply. Previously you would have to write some nasty sub-queries in order to extract the fields from associated tables in QuickBooks so this simplifies the process by letting you access the fields from the top-level.

## Batching/pagination
Now when executing a query we send a initial request to get the total number of rows. If your query returns more than 1k rows we iterate and build the result from separate requests to the API. If there are more than 30k rows then we batch each group of 30k together. These are the limits imposed by the QuickBooks API.