### PR TITLE
Add OAuth access token as a parameter

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,0 +1,84 @@
+<component name="ProjectCodeStyleConfiguration">
+  <code_scheme name="Project" version="173">
+    <JSCodeStyleSettings version="0">
+      <option name="SPACE_BEFORE_FUNCTION_LEFT_PARENTH" value="false" />
+      <option name="SPACES_WITHIN_IMPORTS" value="true" />
+      <option name="FUNCTION_EXPRESSION_BRACE_STYLE" value="5" />
+    </JSCodeStyleSettings>
+    <TypeScriptCodeStyleSettings version="0">
+      <option name="SPACE_BEFORE_FUNCTION_LEFT_PARENTH" value="false" />
+      <option name="SPACES_WITHIN_IMPORTS" value="true" />
+      <option name="FUNCTION_EXPRESSION_BRACE_STYLE" value="5" />
+    </TypeScriptCodeStyleSettings>
+    <codeStyleSettings language="JavaScript">
+      <option name="BRACE_STYLE" value="5" />
+      <option name="CLASS_BRACE_STYLE" value="5" />
+      <option name="METHOD_BRACE_STYLE" value="5" />
+      <option name="ELSE_ON_NEW_LINE" value="true" />
+      <option name="CATCH_ON_NEW_LINE" value="true" />
+      <option name="FINALLY_ON_NEW_LINE" value="true" />
+      <option name="ALIGN_MULTILINE_BINARY_OPERATION" value="true" />
+      <option name="ALIGN_MULTILINE_TERNARY_OPERATION" value="true" />
+      <option name="ALIGN_MULTILINE_ARRAY_INITIALIZER_EXPRESSION" value="true" />
+      <option name="SPACE_BEFORE_IF_PARENTHESES" value="false" />
+      <option name="SPACE_BEFORE_WHILE_PARENTHESES" value="false" />
+      <option name="SPACE_BEFORE_FOR_PARENTHESES" value="false" />
+      <option name="SPACE_BEFORE_CATCH_PARENTHESES" value="false" />
+      <option name="SPACE_BEFORE_SWITCH_PARENTHESES" value="false" />
+      <option name="CALL_PARAMETERS_WRAP" value="5" />
+      <option name="EXTENDS_LIST_WRAP" value="1" />
+      <option name="EXTENDS_KEYWORD_WRAP" value="1" />
+      <option name="METHOD_CALL_CHAIN_WRAP" value="5" />
+      <option name="BINARY_OPERATION_WRAP" value="5" />
+      <option name="TERNARY_OPERATION_WRAP" value="1" />
+      <option name="ARRAY_INITIALIZER_WRAP" value="5" />
+      <option name="ARRAY_INITIALIZER_LBRACE_ON_NEXT_LINE" value="true" />
+      <option name="ARRAY_INITIALIZER_RBRACE_ON_NEXT_LINE" value="true" />
+      <option name="ASSIGNMENT_WRAP" value="1" />
+      <option name="IF_BRACE_FORCE" value="3" />
+      <option name="DOWHILE_BRACE_FORCE" value="3" />
+      <option name="WHILE_BRACE_FORCE" value="3" />
+      <option name="FOR_BRACE_FORCE" value="3" />
+      <indentOptions>
+        <option name="INDENT_SIZE" value="3" />
+        <option name="CONTINUATION_INDENT_SIZE" value="3" />
+        <option name="TAB_SIZE" value="3" />
+      </indentOptions>
+    </codeStyleSettings>
+    <codeStyleSettings language="TypeScript">
+      <option name="BRACE_STYLE" value="5" />
+      <option name="CLASS_BRACE_STYLE" value="5" />
+      <option name="METHOD_BRACE_STYLE" value="5" />
+      <option name="ELSE_ON_NEW_LINE" value="true" />
+      <option name="CATCH_ON_NEW_LINE" value="true" />
+      <option name="FINALLY_ON_NEW_LINE" value="true" />
+      <option name="ALIGN_MULTILINE_BINARY_OPERATION" value="true" />
+      <option name="ALIGN_MULTILINE_TERNARY_OPERATION" value="true" />
+      <option name="ALIGN_MULTILINE_ARRAY_INITIALIZER_EXPRESSION" value="true" />
+      <option name="SPACE_BEFORE_IF_PARENTHESES" value="false" />
+      <option name="SPACE_BEFORE_WHILE_PARENTHESES" value="false" />
+      <option name="SPACE_BEFORE_FOR_PARENTHESES" value="false" />
+      <option name="SPACE_BEFORE_CATCH_PARENTHESES" value="false" />
+      <option name="SPACE_BEFORE_SWITCH_PARENTHESES" value="false" />
+      <option name="CALL_PARAMETERS_WRAP" value="5" />
+      <option name="EXTENDS_LIST_WRAP" value="1" />
+      <option name="EXTENDS_KEYWORD_WRAP" value="1" />
+      <option name="METHOD_CALL_CHAIN_WRAP" value="5" />
+      <option name="BINARY_OPERATION_WRAP" value="5" />
+      <option name="TERNARY_OPERATION_WRAP" value="1" />
+      <option name="ARRAY_INITIALIZER_WRAP" value="5" />
+      <option name="ARRAY_INITIALIZER_LBRACE_ON_NEXT_LINE" value="true" />
+      <option name="ARRAY_INITIALIZER_RBRACE_ON_NEXT_LINE" value="true" />
+      <option name="ASSIGNMENT_WRAP" value="1" />
+      <option name="IF_BRACE_FORCE" value="3" />
+      <option name="DOWHILE_BRACE_FORCE" value="3" />
+      <option name="WHILE_BRACE_FORCE" value="3" />
+      <option name="FOR_BRACE_FORCE" value="3" />
+      <indentOptions>
+        <option name="INDENT_SIZE" value="3" />
+        <option name="CONTINUATION_INDENT_SIZE" value="3" />
+        <option name="TAB_SIZE" value="3" />
+      </indentOptions>
+    </codeStyleSettings>
+  </code_scheme>
+</component>

--- a/.idea/encodings.xml
+++ b/.idea/encodings.xml
@@ -4,6 +4,9 @@
     <file url="file://$PROJECT_DIR$" charset="UTF-8" />
     <file url="file://$PROJECT_DIR$/spark-quickbooks" charset="UTF-8" />
     <file url="file://$PROJECT_DIR$/spark-quickbooks-api" charset="UTF-8" />
+    <file url="file://$PROJECT_DIR$/spark-quickbooks-api/src/main/java" charset="UTF-8" />
     <file url="file://$PROJECT_DIR$/spark-quickbooks-runtime" charset="UTF-8" />
+    <file url="file://$PROJECT_DIR$/spark-quickbooks-runtime/src/main/java" charset="UTF-8" />
+    <file url="file://$PROJECT_DIR$/spark-quickbooks/src/main/java" charset="UTF-8" />
   </component>
 </project>

--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@ If the account is set up correctly you will be able to generate tokens and make 
 Note that the authorization code is one time use so if you need new tokens you will need to first
 get a new authorization code.
 
+If you have already generated an access token you can pass that as an option instead of having
+the data source manage the OAuth flow.
+
 The data source is implemented as `DataSourceV2` which cannot be accessed through the SQL syntax
 in Spark 2.3.2. You will need to use the Java or Scala API to use this connector.
 
@@ -37,30 +40,40 @@ artifactId: spark-quickbooks-api
 version: 1.1.0
 ```
 
-## Options
+## General Options
 
 | Option            | Description                       |
 | ----------------- |---------------------------------- |
-| authorizationCode | OAuth Authorization Code          |
 | companyId         | QuickBooks Online Company ID      |
-| clientId          | OAuth Client ID                   |
-| clientSecret      | OAuthClientSecret                 |
-| redirectUri       | HTTPS endpoint for OAuth redirect |
 | entity            | Object to query from the API      |
 | production        | Query production environment      |
 | expandArrays      | Expands nested arrays to columns  |
 
-* `authorizationCode`: Exchanged for access/refresh tokens
 * `companyId`: Also called `realmId`, it's the ID of the company that you want to query in QuickBooks
-* `clientId`: From your app's **Keys** tab
-* `clientSecret`: From your app's **Keys** tab
-* `redirectUri`: Also in the **Keys** tab, this need to be HTTPS in production and cannot be localhost
-  * Default: `https://developer.intuit.com/v2/OAuth2Playground/RedirectUrl`
 * `entity`: Due to the nature of the QuickBooks Online query syntax, only 1 entity may be queried at a time.
 * `production`: set to `true` when switching from a sandbox to production environment
 * `expandArrays`: `true` to expand every element in an array to its own column
     * `lineItems: [{price: 7.0}, {price: 3.0}]` becomes `lineItems_0_price, lineItems_1_price`
     with the value 7.0 and 3.0 respectively
+
+## OAuth Options
+
+| Option            | Description                       |
+| ----------------- |---------------------------------- |
+| accessToken       | OAuth Access Token                |
+| authorizationCode | OAuth Authorization Code          |
+| clientId          | OAuth Client ID                   |
+| clientSecret      | OAuthClientSecret                 |
+| redirectUri       | HTTPS endpoint for OAuth redirect |
+
+* `accessToken`: OAuth access token if you have already generated one. If you pass an access token
+you don't need to pass any other OAuth options and we'll try to use your token instead of going
+through the authorization process.
+* `authorizationCode`: Exchanged for access/refresh tokens
+* `clientId`: From your app's **Keys** tab
+* `clientSecret`: From your app's **Keys** tab
+* `redirectUri`: Also in the **Keys** tab, this need to be HTTPS in production and cannot be localhost
+  * Default: `https://developer.intuit.com/v2/OAuth2Playground/RedirectUrl`
 
 We take this entity and pass it as the query `select * from <entity>` and then create a data frame
 from the result set to query against with Spark SQL

--- a/spark-quickbooks-api/src/main/java/inetsoft/spark/quickbooks/QuickbooksAPI.java
+++ b/spark-quickbooks-api/src/main/java/inetsoft/spark/quickbooks/QuickbooksAPI.java
@@ -17,8 +17,12 @@ package inetsoft.spark.quickbooks;
 
 import java.util.List;
 
+/**
+ * Public API for the QuickBooks runtime implementation
+ */
 public interface QuickbooksAPI {
-   QuickbooksQueryResult loadData(String accessToken, String clientId,
+   QuickbooksQueryResult loadData(String accessToken,
+                                  String clientId,
                                   String clientSecret,
                                   String authorizationCode,
                                   String companyID,

--- a/spark-quickbooks-api/src/main/java/inetsoft/spark/quickbooks/QuickbooksAPI.java
+++ b/spark-quickbooks-api/src/main/java/inetsoft/spark/quickbooks/QuickbooksAPI.java
@@ -18,7 +18,7 @@ package inetsoft.spark.quickbooks;
 import java.util.List;
 
 public interface QuickbooksAPI {
-   QuickbooksQueryResult loadData(String clientId,
+   QuickbooksQueryResult loadData(String accessToken, String clientId,
                                   String clientSecret,
                                   String authorizationCode,
                                   String companyID,

--- a/spark-quickbooks-runtime/src/main/java/inetsoft/spark/quickbooks/QueryExecutor.java
+++ b/spark-quickbooks-runtime/src/main/java/inetsoft/spark/quickbooks/QueryExecutor.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2020 InetSoft Technology
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package inetsoft.spark.quickbooks;
+
+import com.intuit.ipp.exception.FMSException;
+import com.intuit.ipp.services.QueryResult;
+
+public interface QueryExecutor {
+   QueryResult execute(String token, String companyId,
+                       boolean production, String entity) throws FMSException;
+}

--- a/spark-quickbooks-runtime/src/main/java/inetsoft/spark/quickbooks/QueryExecutorService.java
+++ b/spark-quickbooks-runtime/src/main/java/inetsoft/spark/quickbooks/QueryExecutorService.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2020 InetSoft Technology
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package inetsoft.spark.quickbooks;
+
+import com.intuit.ipp.core.*;
+import com.intuit.ipp.exception.FMSException;
+import com.intuit.ipp.security.OAuth2Authorizer;
+import com.intuit.ipp.services.*;
+import com.intuit.ipp.util.Config;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.invoke.MethodHandles;
+import java.util.ArrayList;
+import java.util.List;
+
+public class QueryExecutorService implements QueryExecutor {
+   @Override
+   public QueryResult execute(String token, String companyId,
+                              boolean production, String entity) throws FMSException
+   {
+      final String apiUrl = production ? productionUrl : sandboxUrl;
+      Config.setProperty(Config.BASE_URL_QBO, apiUrl);
+      final OAuth2Authorizer oauth = new OAuth2Authorizer(token);
+      final Context context = new Context(oauth, ServiceType.QBO, companyId);
+      final DataService service = new DataService(context);
+
+      // first execute a count query to determine pagination
+      final int totalCount = getTotalCount(service, entity);
+
+      // next execute paginated results until complete
+      final QueryResult queryResult = new QueryResult();
+      int startPosition = 1;
+      queryResult.setStartPosition(startPosition);
+      queryResult.setTotalCount(totalCount);
+      queryResult.setMaxResults(totalCount);
+      final ArrayList<IEntity> entities = new ArrayList<>();
+      BatchOperation batchOperation = new BatchOperation();
+      int counter = 0;
+
+      for(int remaining = totalCount; remaining > 0; remaining -= RESULT_LIMIT) {
+         final int maxResults = Math.min(RESULT_LIMIT, remaining);
+         final String query = String.format("SELECT * FROM %s STARTPOSITION %d MAXRESULTS %d",
+                                            entity,
+                                            startPosition,
+                                            maxResults);
+         batchOperation.addQuery(query, String.valueOf(counter++));
+         startPosition += RESULT_LIMIT;
+
+         if(counter % BATCH_LIMIT == 0) {
+            executeBatchOperation(service, entities, batchOperation);
+            batchOperation = new BatchOperation();
+         }
+      }
+
+      executeBatchOperation(service, entities, batchOperation);
+      queryResult.setEntities(entities);
+      return queryResult;
+   }
+
+   private void executeBatchOperation(DataService service,
+                                      ArrayList<IEntity> entities,
+                                      BatchOperation batchOperation) throws FMSException
+   {
+      final List<String> bIds = batchOperation.getBIds();
+
+      if(bIds.size() > 0) {
+         final String index = bIds.get(0);
+         LOG.debug("Executing QuickBooks query from index: {}", index);
+         service.executeBatch(batchOperation);
+
+         for(String bId : bIds) {
+            final QueryResult queryResponse = batchOperation.getQueryResponse(bId);
+            entities.addAll(queryResponse.getEntities());
+         }
+      }
+   }
+
+   /**
+    * Get the total number of entities in the query response
+    */
+   private int getTotalCount(DataService service, String entity) throws FMSException {
+      final QueryResult countResult = service.executeQuery("SELECT COUNT(*) FROM " + entity);
+      final Integer totalCount = countResult.getTotalCount();
+      LOG.debug("QuickBooks count returned {} result(s)", totalCount);
+      return totalCount != null ? totalCount : 1;
+   }
+
+   // max 30 queries per batch operation
+   public static final int BATCH_LIMIT = 30;
+   // max number of results quickbooks can return in 1 call
+   private static final int RESULT_LIMIT = 1000;
+   private static final String sandboxUrl = "https://sandbox-quickbooks.api.intuit.com/v3/company";
+   private static final String productionUrl = "https://quickbooks.api.intuit.com/v3/company";
+   private static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+}

--- a/spark-quickbooks-runtime/src/main/java/inetsoft/spark/quickbooks/QueryResultAdapter.java
+++ b/spark-quickbooks-runtime/src/main/java/inetsoft/spark/quickbooks/QueryResultAdapter.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2020 InetSoft Technology
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package inetsoft.spark.quickbooks;
+
+import com.intuit.ipp.services.QueryResult;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class QueryResultAdapter implements QuickbooksAPI.QuickbooksQueryResult {
+   public QueryResultAdapter(QueryResult queryResult) {
+      this.queryResult = queryResult;
+   }
+
+   @Override
+   public List<Object> getEntities() {
+      return new ArrayList<>(queryResult.getEntities());
+   }
+
+   @Override
+   public int getStartPosition() {
+      return queryResult.getStartPosition();
+   }
+
+   @Override
+   public int getMaxResults() {
+      return queryResult.getMaxResults();
+   }
+
+   @Override
+   public int getTotalCount() {
+      return queryResult.getTotalCount();
+   }
+
+   private QueryResult queryResult;
+}

--- a/spark-quickbooks-runtime/src/main/java/inetsoft/spark/quickbooks/QuickbooksConfig.java
+++ b/spark-quickbooks-runtime/src/main/java/inetsoft/spark/quickbooks/QuickbooksConfig.java
@@ -22,7 +22,7 @@ import java.io.*;
 import java.lang.invoke.MethodHandles;
 
 /**
- * Manage the storage of the Quickbooks OAuth tokens
+ * Manage the storage of the QuickBooks OAuth tokens
  */
 public class QuickbooksConfig {
    private QuickbooksConfig() {
@@ -60,7 +60,7 @@ public class QuickbooksConfig {
    }
 
    private static File getConfigFile(String clientId, String companyId) {
-      LOG.info("Reading OAuth config file from {}", qbLibDir);
+      LOG.debug("Reading OAuth config file from {}", qbLibDir);
       return new File(qbLibDir, clientId + companyId);
    }
 

--- a/spark-quickbooks-runtime/src/main/java/inetsoft/spark/quickbooks/token/AuthorizationCodeFlowTokenStrategy.java
+++ b/spark-quickbooks-runtime/src/main/java/inetsoft/spark/quickbooks/token/AuthorizationCodeFlowTokenStrategy.java
@@ -1,0 +1,85 @@
+package inetsoft.spark.quickbooks.token;
+
+import com.intuit.oauth2.client.OAuth2PlatformClient;
+import com.intuit.oauth2.config.Environment;
+import com.intuit.oauth2.config.OAuth2Config;
+import com.intuit.oauth2.data.BearerTokenResponse;
+import com.intuit.oauth2.exception.OAuthException;
+import inetsoft.spark.quickbooks.QuickbooksConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.invoke.MethodHandles;
+
+/**
+ * Handle exchanging the authorization code for an access token, saving the tokens to disk, and
+ * refreshing the tokens if necessary.
+ */
+public class AuthorizationCodeFlowTokenStrategy implements TokenStrategy {
+   public AuthorizationCodeFlowTokenStrategy(String clientId,
+                                             String clientSecret,
+                                             String companyId,
+                                             String authorizationCode,
+                                             boolean production,
+                                             String redirectUrl)
+   {
+      this.clientId = clientId;
+      this.companyId = companyId;
+      this.authorizationCode = authorizationCode;
+      this.clientSecret = clientSecret;
+      this.production = production;
+      this.redirectUrl = redirectUrl;
+   }
+
+   @Override
+   public String getAccessToken() throws OAuthException {
+      OAuth2Config oauth2Config = new OAuth2Config.OAuth2ConfigBuilder(clientId, clientSecret)
+         .callDiscoveryAPI(production ? Environment.PRODUCTION : Environment.SANDBOX)
+         .buildConfig();
+      client = new OAuth2PlatformClient(oauth2Config);
+      final QuickbooksConfig config = QuickbooksConfig.readConfig(clientId, companyId);
+      return connect(config);
+   }
+
+   /**
+    * Handle OAuth connection. If the access token is null retrieve new tokens. If the refresh token
+    * has expired and the access token is not null refresh the current access token. Otherwise don't
+    * call any authorization mechanism
+    *
+    * @return the current and valid access token
+    */
+   private String connect(QuickbooksConfig config) throws OAuthException {
+      final String accessToken = config.getAccessToken();
+      final long expiration = config.getExpiration();
+
+      if(accessToken == null) {
+         LOG.debug("Fetching OAuth tokens");
+         final BearerTokenResponse response =
+            client.retrieveBearerTokens(authorizationCode, redirectUrl);
+         config = config.updateCredentials(response.getExpiresIn(),
+                                           response.getAccessToken(),
+                                           response.getRefreshToken(), clientId, companyId);
+      }
+      else {
+         if(expiration > -1 && expiration < System.currentTimeMillis()) {
+            LOG.debug("Refreshing OAuth Tokens");
+            final BearerTokenResponse response;
+            response = client.refreshToken(config.getRefreshToken());
+            config = config.updateCredentials(response.getExpiresIn(),
+                                              response.getAccessToken(),
+                                              response.getRefreshToken(), clientId, companyId);
+         }
+      }
+
+      return config.getAccessToken();
+   }
+
+   private static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+   private final String clientId;
+   private final String companyId;
+   private final String authorizationCode;
+   private final String clientSecret;
+   private final boolean production;
+   private final String redirectUrl;
+   private OAuth2PlatformClient client;
+}

--- a/spark-quickbooks-runtime/src/main/java/inetsoft/spark/quickbooks/token/AuthorizationCodeFlowTokenStrategyBuilder.java
+++ b/spark-quickbooks-runtime/src/main/java/inetsoft/spark/quickbooks/token/AuthorizationCodeFlowTokenStrategyBuilder.java
@@ -1,0 +1,49 @@
+package inetsoft.spark.quickbooks.token;
+
+public class AuthorizationCodeFlowTokenStrategyBuilder {
+   public AuthorizationCodeFlowTokenStrategyBuilder setClientId(String clientId) {
+      this.clientId = clientId;
+      return this;
+   }
+
+   public AuthorizationCodeFlowTokenStrategyBuilder setClientSecret(String clientSecret) {
+      this.clientSecret = clientSecret;
+      return this;
+   }
+
+   public AuthorizationCodeFlowTokenStrategyBuilder setCompanyId(String companyId) {
+      this.companyId = companyId;
+      return this;
+   }
+
+   public AuthorizationCodeFlowTokenStrategyBuilder setAuthorizationCode(String authorizationCode) {
+      this.authorizationCode = authorizationCode;
+      return this;
+   }
+
+   public AuthorizationCodeFlowTokenStrategyBuilder setProduction(boolean production) {
+      this.production = production;
+      return this;
+   }
+
+   public AuthorizationCodeFlowTokenStrategyBuilder setRedirectUrl(String redirectUrl) {
+      this.redirectUrl = redirectUrl;
+      return this;
+   }
+
+   public AuthorizationCodeFlowTokenStrategy build() {
+      return new AuthorizationCodeFlowTokenStrategy(clientId,
+                                                    clientSecret,
+                                                    companyId,
+                                                    authorizationCode,
+                                                    production,
+                                                    redirectUrl);
+   }
+
+   private String clientId;
+   private String clientSecret;
+   private String companyId;
+   private String authorizationCode;
+   private boolean production;
+   private String redirectUrl;
+}

--- a/spark-quickbooks-runtime/src/main/java/inetsoft/spark/quickbooks/token/ExternalOAuthTokenStrategy.java
+++ b/spark-quickbooks-runtime/src/main/java/inetsoft/spark/quickbooks/token/ExternalOAuthTokenStrategy.java
@@ -1,0 +1,18 @@
+package inetsoft.spark.quickbooks.token;
+
+/**
+ * This strategy assumes that OAuth is handled outside of the data source so we just use the given
+ * access token
+ */
+public class ExternalOAuthTokenStrategy implements TokenStrategy {
+   public ExternalOAuthTokenStrategy(String accessToken) {
+      this.accessToken = accessToken;
+   }
+
+   @Override
+   public String getAccessToken() {
+      return accessToken;
+   }
+
+   private final String accessToken;
+}

--- a/spark-quickbooks-runtime/src/main/java/inetsoft/spark/quickbooks/token/TokenStrategy.java
+++ b/spark-quickbooks-runtime/src/main/java/inetsoft/spark/quickbooks/token/TokenStrategy.java
@@ -1,0 +1,11 @@
+package inetsoft.spark.quickbooks.token;
+
+import com.intuit.oauth2.exception.OAuthException;
+
+/**
+ * Token strategies provide their own logic for returning an OAuth access token used to query the
+ * QuickBooks API
+ */
+public interface TokenStrategy {
+   String getAccessToken() throws OAuthException;
+}

--- a/spark-quickbooks-runtime/src/main/java/inetsoft/spark/quickbooks/token/TokenStrategyFactory.java
+++ b/spark-quickbooks-runtime/src/main/java/inetsoft/spark/quickbooks/token/TokenStrategyFactory.java
@@ -1,0 +1,27 @@
+package inetsoft.spark.quickbooks.token;
+
+/**
+ * Determine the type of token strategy to use from the data source options. Passing a non-null
+ * access token will avoid any OAuth handling.
+ */
+public class TokenStrategyFactory {
+   public static TokenStrategy create(String accessToken, String clientId,
+                                      String clientSecret,
+                                      String companyId,
+                                      String authorizationCode,
+                                      boolean production,
+                                      String redirectUrl)
+   {
+      if(accessToken != null) {
+         return new ExternalOAuthTokenStrategy(accessToken);
+      }
+
+      return new AuthorizationCodeFlowTokenStrategyBuilder().setClientId(clientId)
+                                                            .setClientSecret(clientSecret)
+                                                            .setCompanyId(companyId)
+                                                            .setAuthorizationCode(authorizationCode)
+                                                            .setProduction(production)
+                                                            .setRedirectUrl(redirectUrl)
+                                                            .build();
+   }
+}

--- a/spark-quickbooks/src/main/java/inetsoft/spark/quickbooks/source/DefaultSource.java
+++ b/spark-quickbooks/src/main/java/inetsoft/spark/quickbooks/source/DefaultSource.java
@@ -15,15 +15,22 @@
  */
 package inetsoft.spark.quickbooks.source;
 
+import org.apache.spark.sql.sources.DataSourceRegister;
 import org.apache.spark.sql.sources.v2.*;
 import org.apache.spark.sql.sources.v2.reader.DataSourceReader;
 
-public class DefaultSource implements DataSourceV2, ReadSupport {
+public class DefaultSource implements DataSourceV2, ReadSupport, DataSourceRegister {
+   @Override
+   public String shortName() {
+      return "quickbooks";
+   }
+
    @Override
    public DataSourceReader createReader(DataSourceOptions options) {
       final String clientId = options.get("clientId").orElse("");
       final String clientSecret = options.get("clientSecret").orElse("");
       final String authorizationCode = options.get("authorizationCode").orElse("");
+      final String accessToken = options.get("accessToken").orElse("");
       final String companyId = options.get("companyId").orElse("");
       final String redirectUrl = options.get("redirectUrl").orElse(URL);
       final String entity = options.get("entity").orElse("companyInfo");
@@ -33,7 +40,7 @@ public class DefaultSource implements DataSourceV2, ReadSupport {
       final boolean production = options.get("production")
                                         .map(Boolean.TRUE.toString()::equals)
                                         .orElse(false);
-      return new QuickbooksReader(clientId, clientSecret, authorizationCode,
+      return new QuickbooksReader(clientId, clientSecret, authorizationCode, accessToken,
                                   companyId, redirectUrl, production, expandArrays, entity);
    }
 

--- a/spark-quickbooks/src/main/java/inetsoft/spark/quickbooks/source/DefaultSource.java
+++ b/spark-quickbooks/src/main/java/inetsoft/spark/quickbooks/source/DefaultSource.java
@@ -27,11 +27,11 @@ public class DefaultSource implements DataSourceV2, ReadSupport, DataSourceRegis
 
    @Override
    public DataSourceReader createReader(DataSourceOptions options) {
-      final String clientId = options.get("clientId").orElse("");
-      final String clientSecret = options.get("clientSecret").orElse("");
-      final String authorizationCode = options.get("authorizationCode").orElse("");
-      final String accessToken = options.get("accessToken").orElse("");
-      final String companyId = options.get("companyId").orElse("");
+      final String clientId = options.get("clientId").orElse(null);
+      final String clientSecret = options.get("clientSecret").orElse(null);
+      final String authorizationCode = options.get("authorizationCode").orElse(null);
+      final String accessToken = options.get("accessToken").orElse(null);
+      final String companyId = options.get("companyId").orElse(null);
       final String redirectUrl = options.get("redirectUrl").orElse(URL);
       final String entity = options.get("entity").orElse("companyInfo");
       final boolean expandArrays = options.get("expandArrays")

--- a/spark-quickbooks/src/main/java/inetsoft/spark/quickbooks/source/QuickbooksReader.java
+++ b/spark-quickbooks/src/main/java/inetsoft/spark/quickbooks/source/QuickbooksReader.java
@@ -36,6 +36,7 @@ public class QuickbooksReader implements DataSourceReader {
    QuickbooksReader(String clientId,
                     String clientSecret,
                     String authorizationCode,
+                    String accessToken,
                     String companyId,
                     String redirectUrl,
                     boolean production,
@@ -43,7 +44,8 @@ public class QuickbooksReader implements DataSourceReader {
                     String entity)
    {
       this.expandArrays = expandArrays;
-      reader = new QuickbooksStreamReader(clientId, clientSecret, authorizationCode, companyId, redirectUrl, production, entity);
+      reader = new QuickbooksStreamReader(accessToken, clientId, clientSecret, authorizationCode,
+                                          companyId, redirectUrl, production, entity);
    }
 
    @Override

--- a/spark-quickbooks/src/main/java/inetsoft/spark/quickbooks/source/QuickbooksStreamReader.java
+++ b/spark-quickbooks/src/main/java/inetsoft/spark/quickbooks/source/QuickbooksStreamReader.java
@@ -28,7 +28,7 @@ import java.util.List;
  * Load the quickbooks runtime and execute a query
  */
 public class QuickbooksStreamReader implements Serializable {
-   public QuickbooksStreamReader(String clientId,
+   public QuickbooksStreamReader(String accessToken, String clientId,
                                  String clientSecret,
                                  String authorizationCode,
                                  String companyId,
@@ -36,6 +36,7 @@ public class QuickbooksStreamReader implements Serializable {
                                  boolean production,
                                  String entity)
    {
+      this.accessToken = accessToken;
       this.clientId = clientId;
       this.clientSecret = clientSecret;
       this.authorizationCode = authorizationCode;
@@ -53,7 +54,8 @@ public class QuickbooksStreamReader implements Serializable {
             classLoader.loadClass("inetsoft.spark.quickbooks.QuickbooksRuntime");
          final QuickbooksAPI api = (QuickbooksAPI) aClass.newInstance();
          final QuickbooksAPI.QuickbooksQueryResult result =
-            api.loadData(clientId, clientSecret, authorizationCode, companyId, redirectUrl, production, entity);
+            api.loadData(accessToken, clientId, clientSecret, authorizationCode,
+                         companyId, redirectUrl, production, entity);
          return Collections.unmodifiableList(result.getEntities());
       }
       catch(Exception e) {
@@ -70,4 +72,5 @@ public class QuickbooksStreamReader implements Serializable {
    private final String redirectUrl;
    private final boolean production;
    private final String entity;
+   private final String accessToken;
 }


### PR DESCRIPTION
We've internally developed a solution to manage OAuth authorization code flow bypassing the need for the data source to manage OAuth itself. You can now pass the `accessToken` parameter to make the authorization process simpler if you already have an OAuth mechanism external to the data source or if you just want to avoid the hassle of generating new authorization codes in different environments.